### PR TITLE
Update OpenBSD box to 5.8

### DIFF
--- a/openbsd/scripts/postinstall.sh
+++ b/openbsd/scripts/postinstall.sh
@@ -2,17 +2,19 @@
 
 set -e
 
-export PKG_PATH="$MIRROR/pub/OpenBSD/`uname -r`/packages/`arch -s`/"
+uname_r=`uname -r`
+
+export PKG_PATH="$MIRROR/pub/OpenBSD/$uname_r/packages/`arch -s`/"
 
 # set pkg path for users
 echo "export PKG_PATH=\"$PKG_PATH\"" >> /root/.profile
 echo "export PKG_PATH=\"$PKG_PATH\"" >> /home/vagrant/.profile
 
-# install wget/curl
-pkg_add wget curl
+# install sudo, required by Vagrant
+pkg_add sudo--
+
+# passwordless sudo for Vagrant
+echo "vagrant ALL=(ALL) NOPASSWD: SETENV: ALL" >> /etc/sudoers
 
 # ansible support
 pkg_add -z python-2
-
-# sudo
-echo "vagrant ALL=(ALL) NOPASSWD: SETENV: ALL" >> /etc/sudoers

--- a/openbsd/scripts/vagrant.sh
+++ b/openbsd/scripts/vagrant.sh
@@ -3,8 +3,8 @@
 set -e
 
 mkdir -p /home/vagrant/.ssh
-wget --no-check-certificate \
-    'https://github.com/mitchellh/vagrant/raw/master/keys/vagrant.pub' \
-    -O /home/vagrant/.ssh/authorized_keys
+cat <<EOT >/home/vagrant/.ssh/authorized_keys
+ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key
+EOT
 chown -R vagrant /home/vagrant/.ssh
 chmod -R go-rwsx /home/vagrant/.ssh

--- a/openbsd/template.json
+++ b/openbsd/template.json
@@ -28,11 +28,11 @@
       "boot_command": [
         "S<enter>",
         "cat <<EOF >>install.conf<enter>",
-        "System hostname = openbsd57<enter>",
+        "System hostname = openbsd58<enter>",
         "Password for root = vagrant<enter>",
         "Setup a user = vagrant<enter>",
         "Password for user = vagrant<enter>",
-        "Since you set up a user, disable sshd(8) logins to root = no<enter>",
+        "Allow root ssh login = yes<enter>",
         "What timezone are you in = UTC<enter>",
         "Location of sets = cd<enter>",
         "Set name(s) = -game*.tgz -x*.tgz<enter>",
@@ -44,10 +44,10 @@
       "disk_size": 10140,
       "guest_additions_mode": "disable",
       "guest_os_type": "OpenBSD_64",
-      "iso_checksum": "3f714d249a6dc8f40c2fc2fccea8ef9987e74a2b81483175d081661c3533b59a",
+      "iso_checksum": "2edd369c4b5f1960f9c974ee7f7bbe4105137968c1542d37411e83cb79f7f6f2",
       "iso_checksum_type": "sha256",
-      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.7/amd64/install57.iso",
-      "output_directory": "packer-openbsd-5.7-amd64-virtualbox",
+      "iso_url": "{{user `mirror`}}/pub/OpenBSD/5.8/amd64/install58.iso",
+      "output_directory": "packer-openbsd-5.8-amd64-virtualbox",
       "shutdown_command": "/sbin/halt -p",
       "ssh_username": "root",
       "ssh_password": "vagrant",
@@ -58,13 +58,13 @@
         [ "modifyvm", "{{.Name}}", "--cpus", "1" ]
       ],
       "virtualbox_version_file": ".vbox_version",
-      "vm_name": "openbsd-5.7-amd64"
+      "vm_name": "openbsd-5.8-amd64"
     }
   ],
   "post-processors": [
     [{
       "type": "vagrant",
-      "output": "openbsd-5.7-amd64-{{.Provider}}.box",
+      "output": "openbsd-5.8-amd64-{{.Provider}}.box",
       "vagrantfile_template": "Vagrantfile.template"
     }]
   ],


### PR DESCRIPTION
```
$ packer build template.json
virtualbox-iso output will be in this color.

==> virtualbox-iso: Downloading or copying ISO
    virtualbox-iso: Downloading or copying: http://ftp.su.se/pub/OpenBSD/5.8/amd64/install58.iso
==> virtualbox-iso: Creating virtual machine...
==> virtualbox-iso: Creating hard drive...
==> virtualbox-iso: Creating forwarded port mapping for SSH (host port 2973)
==> virtualbox-iso: Executing custom VBoxManage commands...
    virtualbox-iso: Executing: modifyvm openbsd-5.8-amd64 --memory 384
    virtualbox-iso: Executing: modifyvm openbsd-5.8-amd64 --cpus 1
==> virtualbox-iso: Starting the virtual machine...
==> virtualbox-iso: Waiting 30s for boot...
==> virtualbox-iso: Typing the boot command...
==> virtualbox-iso: Waiting for SSH to become available...
==> virtualbox-iso: Connected to SSH!
==> virtualbox-iso: Uploading VirtualBox version info (5.0.12)
==> virtualbox-iso: Provisioning with shell script: scripts/postinstall.sh
    virtualbox-iso: quirks-2.114 signed on 2015-08-09T11:57:52Z
    virtualbox-iso: --- +sudo-1.8.14.3 -------------------
    virtualbox-iso: Please see the /usr/local/share/doc/sudo/UPGRADE file for important
    virtualbox-iso: information about upgrading from a previous version of sudo.
    virtualbox-iso:
    virtualbox-iso: Important user-visible changes compared to the version of sudo that
    virtualbox-iso: used to be in OpenBSD base (1.7.2p8) include:
    virtualbox-iso:
    virtualbox-iso: o The tty_tickets sudoers option is now enabled by default.
    virtualbox-iso: To restore the old behavior (single time stamp per user),
    virtualbox-iso: add a line like:
    virtualbox-iso: Defaults !tty_tickets
    virtualbox-iso: to sudoers.
    virtualbox-iso:
    virtualbox-iso: o  The HOME and MAIL environment variables are now reset based on the
    virtualbox-iso: target user's password database entry when the env_reset sudoers option
    virtualbox-iso: is enabled (which is the case in the default configuration).  Users
    virtualbox-iso: wishing to preserve the original values should use a sudoers line like:
    virtualbox-iso: Defaults env_keep += HOME
    virtualbox-iso: to preserve the old value of HOME and
    virtualbox-iso: Defaults env_keep += MAIL
    virtualbox-iso: to preserve the old value of MAIL.
    virtualbox-iso: quirks-2.114 signed on 2015-08-09T11:57:52Z
    virtualbox-iso: --- +python-2.7.10 -------------------
    virtualbox-iso: If you want to use this package as your default system python, as root
    virtualbox-iso: create symbolic links like so (overwriting any previous default):
    virtualbox-iso: ln -sf /usr/local/bin/python2.7 /usr/local/bin/python
    virtualbox-iso: ln -sf /usr/local/bin/python2.7-2to3 /usr/local/bin/2to3
    virtualbox-iso: ln -sf /usr/local/bin/python2.7-config /usr/local/bin/python-config
    virtualbox-iso: ln -sf /usr/local/bin/pydoc2.7  /usr/local/bin/pydoc
==> virtualbox-iso: Provisioning with shell script: scripts/vagrant.sh
==> virtualbox-iso: Provisioning with shell script: scripts/minimize.sh
    virtualbox-iso: dd: /EMPTY: No space left on device
    virtualbox-iso: 180+0 records in
    virtualbox-iso: 179+0 records out
    virtualbox-iso: 187695104 bytes transferred in 2.997 secs (62607942 bytes/sec)
==> virtualbox-iso: Gracefully halting virtual machine...
==> virtualbox-iso: Preparing to export machine...
    virtualbox-iso: Deleting forwarded port mapping for SSH (host port 2973)
==> virtualbox-iso: Exporting virtual machine...
    virtualbox-iso: Executing: export openbsd-5.8-amd64 --output packer-openbsd-5.8-amd64-virtualbox/openbsd-5.8-amd64.ovf
==> virtualbox-iso: Unregistering and deleting virtual machine...
==> virtualbox-iso: Running post-processor: vagrant
==> virtualbox-iso (vagrant): Creating Vagrant box for 'virtualbox' provider
    virtualbox-iso (vagrant): Copying from artifact: packer-openbsd-5.8-amd64-virtualbox/openbsd-5.8-amd64-disk1.vmdk
    virtualbox-iso (vagrant): Copying from artifact: packer-openbsd-5.8-amd64-virtualbox/openbsd-5.8-amd64.ovf
    virtualbox-iso (vagrant): Renaming the OVF to box.ovf...
    virtualbox-iso (vagrant): Using custom Vagrantfile: Vagrantfile.template
    virtualbox-iso (vagrant): Compressing: Vagrantfile
    virtualbox-iso (vagrant): Compressing: box.ovf
    virtualbox-iso (vagrant): Compressing: metadata.json
    virtualbox-iso (vagrant): Compressing: openbsd-5.8-amd64-disk1.vmdk
Build 'virtualbox-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> virtualbox-iso: 'virtualbox' provider box: openbsd-5.8-amd64-virtualbox.box
```